### PR TITLE
Improve Minecraft log filtering

### DIFF
--- a/Classes/MinecraftLogMonitor.py
+++ b/Classes/MinecraftLogMonitor.py
@@ -99,12 +99,19 @@ class MinecraftLogHandler(FileSystemEventHandler):
         # Censor IP addresses before processing
         log_line = self.censor_ip_addresses(log_line)
             
+        # Filter out stack trace lines to reduce noise
+        if re.match(r'^\s*at\b', log_line):
+            return None
+
         # Extract timestamp and message parts
         # Minecraft log format: [HH:MM:SS] [Thread/LEVEL]: Message
         timestamp_match = re.match(r'\[(\d{2}:\d{2}:\d{2})\] \[([^\]]+)\]: (.+)', log_line)
-        
+
         if not timestamp_match:
-            return f"🔧 `{log_line}`"
+            # Still report lines mentioning exceptions or errors
+            if re.search(r'exception|error|caused by', log_line, re.IGNORECASE):
+                return f"⚠️ `{log_line}`"
+            return None
             
         timestamp, thread_level, message = timestamp_match.groups()
         


### PR DESCRIPTION
## Summary
- prevent spam from Minecraft logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407ad4d700832495f7085313844bdd