### PR TITLE
Fix audio freeze during playback

### DIFF
--- a/Classes/BotBehaviour.py
+++ b/Classes/BotBehaviour.py
@@ -1519,7 +1519,11 @@ class BotBehavior:
             
             # Use original_message for similarity search
             # Fetch N+1 in case the top result is the one being played
-            all_similar = Database().get_sounds_by_similarity(sound_name, num_suggestions + 1)
+            loop = asyncio.get_running_loop()
+            all_similar = await loop.run_in_executor(
+                None,
+                lambda: Database().get_sounds_by_similarity(sound_name, num_suggestions + 1)
+            )
             
             if not all_similar:
                 print(f"No similar sounds found for {sound_name}")

--- a/Classes/Database.py
+++ b/Classes/Database.py
@@ -20,7 +20,8 @@ class Database:
         self._initialized = True
         script_dir = os.path.dirname(os.path.abspath(__file__))
         self.db_path = os.path.join(script_dir, "../database.db")
-        self.conn = sqlite3.connect(self.db_path)
+        # Allow usage from background threads
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self.cursor = self.conn.cursor()
         self.behavior = behavior
 


### PR DESCRIPTION
## Summary
- prevent blocking the event loop when fetching similar sounds by running the database search in an executor
- allow SQLite connection to be used from background threads

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68407b55afcc8324898d9818220a94be