### PR TITLE
Fix slap button emoji

### DIFF
--- a/Classes/UI.py
+++ b/Classes/UI.py
@@ -909,7 +909,8 @@ class ControlsView(View):
         self.add_item(ListFavoritesButton(bot_behavior, label="⭐Favorites⭐", style=discord.ButtonStyle.success))
         self.add_item(ListUserFavoritesButton(bot_behavior, label="💖My Favorites💖", style=discord.ButtonStyle.success))
         self.add_item(ListBlacklistButton(bot_behavior, label="🗑️Blacklisted🗑️", style=discord.ButtonStyle.success))
-        self.add_item(PlaySlapButton(bot_behavior, label="👋/🔫/🍳", style=discord.ButtonStyle.success))
+        # Use a single slap emoji for the slap button label
+        self.add_item(PlaySlapButton(bot_behavior, label="👋", style=discord.ButtonStyle.success))
 
         self.add_item(BrainRotButton(bot_behavior, label="🧠Brain Rot🧠", style=discord.ButtonStyle.success))
         self.add_item(StatsButton(bot_behavior, label="📊Stats📊", style=discord.ButtonStyle.success))


### PR DESCRIPTION
## Summary
- clean up the slap button label so only the slap emoji is shown

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68407f3fc328832480d7667478f482c2