### PR TITLE
Play random sound on initial join

### DIFF
--- a/Classes/Bot.py
+++ b/Classes/Bot.py
@@ -6,6 +6,7 @@ class Bot(commands.Bot):
         super().__init__(command_prefix=command_prefix, intents=intents)
         self.token = token
         self.ffmpeg_path = ffmpeg_path
+        self.startup_sound_played = False
 
     def run_bot(self):
         self.run(self.token)

--- a/PersonalGreeter.py
+++ b/PersonalGreeter.py
@@ -263,6 +263,13 @@ async def on_ready():
                 print(f"Attempting to connect to {channel_to_join.name} in {guild.name}...")
                 await channel_to_join.connect()
                 print(f"Successfully connected to {channel_to_join.name} in {guild.name}.")
+                if not bot.startup_sound_played:
+                    try:
+                        random_sound = Database().get_random_sounds()[0][2]
+                        await behavior.play_audio(channel_to_join, random_sound, "startup")
+                    except Exception as e:
+                        print(f"Error playing startup sound: {e}")
+                    bot.startup_sound_played = True
             except discord.ClientException as e:
                 print(f"Error connecting to {channel_to_join.name} in {guild.name}: {e}. Already connected elsewhere or connection issue.")
             except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary
- track if the bot has already played a startup sound
- after the bot connects to a voice channel on startup, play a random sound once

## Testing
- `python -m py_compile Classes/Bot.py PersonalGreeter.py`

------
https://chatgpt.com/codex/tasks/task_e_684083d596948324a6a5e084a007ab70