### PR TITLE
Increase progress bar update interval

### DIFF
--- a/Classes/BotBehaviour.py
+++ b/Classes/BotBehaviour.py
@@ -841,7 +841,10 @@ class BotBehavior:
                 # Only update the embed content without modifying the view
                 await sound_message.edit(embed=embed)
             
-            await asyncio.sleep(1)  # Update every second
+            # Increase the delay between updates to reduce the frequency of
+            # message edits. This helps determine if frequent updates are
+            # causing short freezes during audio playback.
+            await asyncio.sleep(5)  # Update every five seconds
         
         # Remove only the progress bar when done
         if sound_message and not self.stop_progress_update:


### PR DESCRIPTION
## Summary
- tune playback overlay updates to every 5 seconds instead of 1

## Testing
- `python -m py_compile Classes/BotBehaviour.py`

------
https://chatgpt.com/codex/tasks/task_e_6840939f17608324a553b738cf668ce1