### PR TITLE
Fix AFK channel event handling

### DIFF
--- a/PersonalGreeter.py
+++ b/PersonalGreeter.py
@@ -844,6 +844,11 @@ async def on_voice_state_update(member: discord.Member, before: discord.VoiceSta
         channel = after.channel
     else:
         return  # No relevant change
+
+    # Skip if the user joined the server's AFK channel
+    if event == "join" and channel and channel == channel.guild.afk_channel:
+        print(f"Ignoring join event for {member_str} in AFK channel {channel}")
+        return
         
     # Log the voice state update
     print(f"Voice state update: {member_str} {event} channel {channel}")


### PR DESCRIPTION
## Summary
- prevent join events from triggering sounds when a user joins the server's AFK channel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68445b99d0988324bc0a67a599775637