### PR TITLE
Fix AFK channel event handling

### DIFF
--- a/PersonalGreeter.py
+++ b/PersonalGreeter.py
@@ -844,6 +844,20 @@ async def on_voice_state_update(member: discord.Member, before: discord.VoiceSta
         channel = after.channel
     else:
         return  # No relevant change
+
+    # Handle AFK channel joins
+    if event == "join" and channel and channel == channel.guild.afk_channel:
+        if before.channel:
+            # Treat moving to AFK as leaving the previous channel
+            print(
+                f"User {member_str} moved to AFK channel {channel}; treating as leave from {before.channel}"
+            )
+            event = "leave"
+            channel = before.channel
+        else:
+            # Ignore when directly joining the AFK channel
+            print(f"Ignoring join event for {member_str} in AFK channel {channel}")
+            return
         
     # Log the voice state update
     print(f"Voice state update: {member_str} {event} channel {channel}")


### PR DESCRIPTION
## Summary
- prevent join events from triggering sounds when a user joins the server's AFK channel
- instead treat AFK moves as leave events so leave sounds still play

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68445b99d0988324bc0a67a599775637