### PR TITLE
Reduce CPU spikes during similarity search

### DIFF
--- a/Classes/BotBehaviour.py
+++ b/Classes/BotBehaviour.py
@@ -1530,6 +1530,7 @@ class BotBehavior:
                     Database().get_sounds_by_similarity,
                     sound_name,
                     num_suggestions + 1,
+                    0.001,
                 ),
             )
             
@@ -1591,7 +1592,7 @@ class BotBehavior:
             loop = asyncio.get_running_loop()
             similar_sounds = await loop.run_in_executor(
                 None,
-                functools.partial(Database().get_sounds_by_similarity, sound_name, 6),
+                functools.partial(Database().get_sounds_by_similarity, sound_name, 6, 0.001),
             )  # Get 6 to ensure we have enough after filtering
             similar_sounds = [s for s in similar_sounds if s[1] != audio_file][:5]  # Limit to 5
             

--- a/Classes/Database.py
+++ b/Classes/Database.py
@@ -3,6 +3,7 @@ import os
 import csv
 import json
 import datetime
+import time
 from fuzzywuzzy import fuzz
 
 class Database:
@@ -176,7 +177,9 @@ class Database:
             text = text.replace(key, value)
         return text.lower()
 
-    def get_sounds_by_similarity(self, req_sound, num_results=5):
+    def get_sounds_by_similarity(self, req_sound, num_results=5, sleep_interval=0.0):
+        """Return the most similar sounds. Optionally sleep between iterations
+        to reduce CPU spikes that can cause audio stutter."""
         # Normalize the requested sound to handle character substitutions
         normalized_req = self.normalize_text(req_sound)
         try:
@@ -204,6 +207,9 @@ class Database:
                 combined_score = (0.5 * token_set_score) + (0.3 * partial_ratio_score) + (0.2 * token_sort_score)
 
                 scored_matches.append((combined_score, sound))
+
+                if sleep_interval:
+                    time.sleep(sleep_interval)
             
             # Sort the matches by combined score in descending order
             scored_matches.sort(key=lambda x: x[0], reverse=True)


### PR DESCRIPTION
## Summary
- throttle the fuzzy matching loop by adding a small optional delay
- expose `sleep_interval` argument for `get_sounds_by_similarity`
- call the heavy search with a delay so playback is smoother

## Testing
- `python -m py_compile Classes/Database.py Classes/BotBehaviour.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483842980c8324ac8480e80c12acd3