### PR TITLE
Add loading placeholder and faster updates

### DIFF
--- a/Classes/BotBehaviour.py
+++ b/Classes/BotBehaviour.py
@@ -15,7 +15,15 @@ from Classes.PlayHistoryDatabase import PlayHistoryDatabase
 from Classes.OtherActionsDatabase import OtherActionsDatabase
 from Classes.TTS import TTS
 import csv
-from Classes.UI import SoundBeingPlayedView, SoundBeingPlayedWithSuggestionsView, ControlsView, SoundView, EventView, PaginatedEventView
+from Classes.UI import (
+    SoundBeingPlayedView,
+    SoundBeingPlayedWithSuggestionsView,
+    LoadingSimilarSoundsSelect,
+    ControlsView,
+    SoundView,
+    EventView,
+    PaginatedEventView,
+)
 from Classes.ManualSoundDownloader import ManualSoundDownloader
 from moviepy.editor import VideoFileClip
 
@@ -606,14 +614,18 @@ class BotBehavior:
                     description.append(f"⏱️ Duration: {duration_str}")
                     description.append(f"Progress: Loading...")
                     description_text = "\n".join(description) if description else None
-                    
+
+                    view = SoundBeingPlayedView(self, audio_file, include_add_to_list_select=False)
+                    if show_suggestions and not is_entrance and not is_tts and not is_slap_sound:
+                        view.add_item(LoadingSimilarSoundsSelect())
+
                     sound_message = await self.send_message(
-                        view=SoundBeingPlayedView(self, audio_file, include_add_to_list_select=False),
+                        view=view,
                         title=f"🔊 **{sound_info[2].replace('.mp3', '') if sound_info and len(sound_info) > 2 else audio_file.replace('.mp3', '')}** 🔊",
                         description=description_text,
                         footer=f"{user} requested '{original_message}'" if original_message else f"Requested by {user}",
                         # Only send controls on the main message if no similar sounds are being shown
-                        send_controls=True   
+                        send_controls=True
                     )
 
                     
@@ -844,7 +856,7 @@ class BotBehavior:
             # Increase the delay between updates to reduce the frequency of
             # message edits. This helps determine if frequent updates are
             # causing short freezes during audio playback.
-            await asyncio.sleep(5)  # Update every five seconds
+            await asyncio.sleep(1)  # Update every second
         
         # Remove only the progress bar when done
         if sound_message and not self.stop_progress_update:

--- a/Classes/UI.py
+++ b/Classes/UI.py
@@ -1259,6 +1259,17 @@ class SimilarSoundsSelect(discord.ui.Select):
         else:
             await interaction.followup.send("You need to be in a voice channel to play sounds! 😭", ephemeral=True)
 
+class LoadingSimilarSoundsSelect(discord.ui.Select):
+    def __init__(self):
+        super().__init__(
+            placeholder="Loading similar sounds...",
+            min_values=1,
+            max_values=1,
+            options=[discord.SelectOption(label="Loading...", value="loading")],
+            disabled=True,
+            row=3,
+        )
+
 class AddToListSelect(discord.ui.Select):
     def __init__(self, bot_behavior, sound_filename, lists, default_list_id: int = None):
         self.bot_behavior = bot_behavior

--- a/templates/index.html
+++ b/templates/index.html
@@ -345,7 +345,7 @@
         setupBackendSearch('searchAllSounds', fetchAllSounds);
         // --- End of Backend Search Trigger ---
 
-        // Auto-refresh every 5 seconds (adjust as needed)
+        // Auto-refresh every 1 second (adjust as needed)
         setInterval(() => {
             Promise.all([fetchActions(), fetchFavorites(), fetchAllSounds()])
                 .then(results => {
@@ -357,7 +357,7 @@
                         // console.log('No new entries, no table update needed.');
                     }
                 });
-        }, 5000); // Changed interval to 5000ms
+        }, 1000); // Changed interval to 1000ms
 
         // Initial data fetch
         fetchActions();


### PR DESCRIPTION
## Summary
- show a loading placeholder select while searching for similar sounds
- speed up progress bar updates to 1 second
- refresh page data every second

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483b0d2b7483248f053a985c3a2d3b