### PR TITLE
Fix delayed similar sound suggestions

### DIFF
--- a/Classes/BotBehaviour.py
+++ b/Classes/BotBehaviour.py
@@ -1542,7 +1542,7 @@ class BotBehavior:
                     Database().get_sounds_by_similarity,
                     sound_name,
                     num_suggestions + 1,
-                    0.001,
+                    0.00001,
                 ),
             )
             


### PR DESCRIPTION
## Summary
- tweak lookup delay for similar sound search so results are ready during playback

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68483dc2a3b0832483d29a24cfb93595