### PR TITLE
Improve dropdown placement

### DIFF
--- a/Classes/UI.py
+++ b/Classes/UI.py
@@ -666,7 +666,7 @@ class SoundBeingPlayedView(View):
                 # Ensure AddToListSelect can fit, check component count if necessary
                 if len(self.children) < 25: # Basic check for component limit
                     # Pass the default_list_id to AddToListSelect
-                    self.add_item(AddToListSelect(self.bot_behavior, self.audio_file, lists, default_list_id=default_list_id))
+                    self.add_item(AddToListSelect(self.bot_behavior, self.audio_file, lists, default_list_id=default_list_id, row=4))
                 else:
                     print("Warning: Could not add AddToListSelect to SoundBeingPlayedView due to component limit.")
                     # Fallback to button maybe? Or just omit. For now, omit if limit reached.
@@ -725,7 +725,7 @@ class SoundBeingPlayedWithSuggestionsView(View):
                 # Ensure AddToListSelect can fit, check component count if necessary
                 if len(self.children) < 25: # Basic check for component limit
                     # Pass the default_list_id to AddToListSelect
-                    self.add_item(AddToListSelect(self.bot_behavior, self.audio_file, lists, default_list_id=default_list_id))
+                    self.add_item(AddToListSelect(self.bot_behavior, self.audio_file, lists, default_list_id=default_list_id, row=4))
                 else:
                     print("Warning: Could not add AddToListSelect to SoundBeingPlayedView due to component limit.")
                     # Fallback to button maybe? Or just omit. For now, omit if limit reached.
@@ -1271,7 +1271,7 @@ class LoadingSimilarSoundsSelect(discord.ui.Select):
         )
 
 class AddToListSelect(discord.ui.Select):
-    def __init__(self, bot_behavior, sound_filename, lists, default_list_id: int = None):
+    def __init__(self, bot_behavior, sound_filename, lists, default_list_id: int = None, row: int = 0):
         self.bot_behavior = bot_behavior
         self.sound_filename = sound_filename
 
@@ -1293,7 +1293,8 @@ class AddToListSelect(discord.ui.Select):
             placeholder="Choose a list...",
             min_values=1,
             max_values=1,
-            options=options
+            options=options,
+            row=row
         )
 
     async def callback(self, interaction):


### PR DESCRIPTION
## Summary
- allow AddToListSelect to accept a row parameter
- place AddToList dropdown in row 4 of the sound view so it appears under the "Play a similar sound..." menu

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c4f7ced4083249bd739ac5730c7ea