### PR TITLE
Fix Instagram URL name handling

### DIFF
--- a/PersonalGreeter.py
+++ b/PersonalGreeter.py
@@ -905,7 +905,7 @@ async def on_message(message):
             r'https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)' # YouTube (youtube.com/watch?v= or youtu.be/)
             r'[\w-]+'                                           # Matches the video ID
             r'(?:[?#][^\s]*)?'                                   # Optional query/fragment
-            r')\b'                                            # Word boundary to prevent partial matches
+            r')(?=\s|$)'                                       # Positive lookahead for space or end of string (instead of word boundary)
         )
         match = url_pattern.search(message.content)
 


### PR DESCRIPTION
Fix Instagram URL parsing to prevent `==` from being included in sound names.

The original regex used `\b` (word boundary) which incorrectly stopped matching before `==` characters in Instagram URLs (e.g., `?igsh=...==`). This caused the `==` to be parsed as part of the custom sound name. The fix replaces `\b` with `(?=\s|$)` to correctly capture the full URL, ensuring only the intended custom name is extracted.