### PR TITLE
Add lastlogs command

### DIFF
--- a/Classes/MinecraftLogMonitor.py
+++ b/Classes/MinecraftLogMonitor.py
@@ -174,6 +174,24 @@ class MinecraftLogHandler(FileSystemEventHandler):
         else:
             return discord.Color.blue()
 
+    def get_last_logs(self, lines=10):
+        """Return the last `lines` entries from the log file formatted"""
+        if not os.path.exists(self.log_file_path):
+            return []
+
+        try:
+            with open(self.log_file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                log_lines = f.readlines()[-lines:]
+            formatted = []
+            for line in log_lines:
+                msg = self.format_log_message(line.strip())
+                if msg:
+                    formatted.append(msg)
+            return formatted
+        except Exception as e:
+            print(f"Error getting last logs: {e}")
+            return []
+
 
 class MinecraftLogMonitor:
     def __init__(self, discord_bot, channel_name="minecraft"):
@@ -229,4 +247,10 @@ class MinecraftLogMonitor:
                 return False
         else:
             print(f"Could not find channel '#{self.channel_name}'")
-            return False 
+            return False
+
+    def get_last_logs(self, lines=10):
+        """Get the last formatted log lines"""
+        if not self.handler:
+            return []
+        return self.handler.get_last_logs(lines)

--- a/PersonalGreeter.py
+++ b/PersonalGreeter.py
@@ -1035,6 +1035,20 @@ async def minecraft_logs(ctx,
         else:
             await ctx.respond("⚠️ Minecraft log monitoring is not running. Start it first with `/minecraft start`")
 
+@bot.slash_command(name="lastlogs", description="Show the last Minecraft logs")
+async def last_logs(ctx, lines: Option(int, "Number of log lines", required=False, default=10)):
+    if minecraft_monitor.observer and minecraft_monitor.observer.is_alive():
+        logs = minecraft_monitor.get_last_logs(lines)
+        if not logs:
+            await ctx.respond("No log entries found.")
+            return
+        formatted = "\n".join(logs)
+        if len(formatted) > 1900:
+            formatted = formatted[-1900:]
+        await ctx.respond(f"```{formatted}```")
+    else:
+        await ctx.respond("⚠️ Minecraft log monitoring is not running.")
+
 @bot.slash_command(name="reboot", description="Reboots the host machine (Admin only).")
 async def reboot_command(ctx):
     """Reboots the machine the bot is running on. Requires admin permissions."""


### PR DESCRIPTION
## Summary
- support retrieving last log lines from Minecraft log monitor
- expose /lastlogs slash command to show recent logs

## Testing
- `python -m py_compile PersonalGreeter.py Classes/MinecraftLogMonitor.py`

------
https://chatgpt.com/codex/tasks/task_e_686a4ec3b4648324b28e1577959208a0