### PR TITLE
Fix discord bot voice client error

### DIFF
--- a/Classes/SpeechRecognition.py
+++ b/Classes/SpeechRecognition.py
@@ -588,7 +588,7 @@ class DiscordVoiceListener:
                         voice_client.listening_sink = sink
                         
                         # Required callback format for Discord's recording system
-                        def recording_callback(sink, *args):
+                        async def recording_callback(sink, *args):
                             """Callback required by `start_recording`.
 
                             The library invokes this function once the recording


### PR DESCRIPTION
Make `recording_callback` asynchronous to fix `TypeError` and prevent bot from leaving voice channels.

The `py-cord` library (a Discord.py fork) expects the callback function passed to `voice_client.start_recording()` to be a coroutine object. The previous synchronous definition of `recording_callback` caused a `TypeError: A coroutine object is required`, leading to the bot disconnecting from voice channels.